### PR TITLE
add properties_content field

### DIFF
--- a/src/main/java/ru/idfedorov09/telegram/bot/data/model/ProfileResponse.kt
+++ b/src/main/java/ru/idfedorov09/telegram/bot/data/model/ProfileResponse.kt
@@ -22,5 +22,8 @@ data class ProfileResponse(
     val isRunning: Boolean,
 
     @SerialName("has_properties")
-    val hasProperties: Boolean
+    val hasProperties: Boolean,
+
+    @SerialName("properties_content")
+    val propertyContent: String?,
 )

--- a/src/main/java/ru/idfedorov09/telegram/bot/fetchers/bot/ManageProfilesFetcher.kt
+++ b/src/main/java/ru/idfedorov09/telegram/bot/fetchers/bot/ManageProfilesFetcher.kt
@@ -673,6 +673,20 @@ class ManageProfilesFetcher(
             ),
         )
 
+        // TODO: сделать рабочей кнопкой
+        val propertyContentButton = if (profileResponse.hasProperties) {
+            val callbackProp = callbackDataRepository.save(
+                CallbackData(
+                    messageId = messageId,
+                    callbackData = "#show_prop|$profileName",
+                ),
+            )
+            InlineKeyboardButton().also {
+                it.text = "\uD83D\uDD16 Показать проперти"
+                it.callbackData = callbackProp.id.toString()
+            }
+        } else { null }
+
         val buttons = createRunOrRerunButton(profileResponse, messageId).chunked(1).toMutableList()
         buttons.addAll(
             listOf(
@@ -694,12 +708,19 @@ class ManageProfilesFetcher(
                         it.callbackData = callbackRemove.id.toString()
                     },
                 ),
-                listOf(
-                    InlineKeyboardButton().also {
-                        it.text = "◀\uFE0F Назад"
-                        it.callbackData = callbackBack.id.toString()
-                    },
-                ),
+            ),
+        )
+
+        propertyContentButton?.let {
+            buttons.add(listOf(it))
+        }
+
+        buttons.add(
+            listOf(
+                InlineKeyboardButton().also {
+                    it.text = "◀\uFE0F Назад"
+                    it.callbackData = callbackBack.id.toString()
+                },
             ),
         )
 

--- a/src/main/java/ru/idfedorov09/telegram/bot/service/Cd2bService.kt
+++ b/src/main/java/ru/idfedorov09/telegram/bot/service/Cd2bService.kt
@@ -194,6 +194,13 @@ class Cd2bService {
                     stackTrace = e.stackTraceToString(),
                 ).addTo(errorsList)
             }
+            else -> {
+                Cd2bError(
+                    statusCode = -666,
+                    statusDescription = "Unknown error",
+                    stackTrace = e.stackTraceToString(),
+                ).addTo(errorsList)
+            }
         }
 
         return errorsList


### PR DESCRIPTION
- По контракту, в `ProfileResponse` добавили новое поле `properties_content`, которое является отображением файла с текущими пропертями бота. Добавлена соответствующая кнопка, но пока не рабочая
- Добавлена обработка неизвестных ошибок сервера (пока что поставил код `-666`)